### PR TITLE
Class methods

### DIFF
--- a/lib/missingly/matchers.rb
+++ b/lib/missingly/matchers.rb
@@ -22,7 +22,7 @@ module Missingly
           setup_delegation_handlers(matcher, options, options[:to])
         end
       end
-            
+
       def setup_custom_handler(matcher, options, &block)
         missingly_matchers[matcher] = options[:with].new(matcher, options, block)
       end
@@ -84,7 +84,7 @@ module Missingly
         end
         missingly_subclasses << subclass
       end
-      
+
       def method_missing(method_name, *args, &block)
         missingly_matchers.values.each do |matcher|
           next unless matcher.should_respond_to?(self, method_name)
@@ -104,7 +104,7 @@ module Missingly
         end
         super
       end
-      
+
       def respond_to_missing?(method_name, include_all)
         self.missingly_matchers.values.each do |matcher|
           return true if matcher.should_respond_to?(self, method_name.to_sym) && matcher.options[:class_method]
@@ -140,7 +140,7 @@ module Missingly
       end
       super
     end
-    
+
     private
 
     def self.included(klass)

--- a/spec/class_methods_spec.rb
+++ b/spec/class_methods_spec.rb
@@ -4,49 +4,49 @@ describe Missingly::Matchers do
   let(:search_class) do
     Class.new do
       include Missingly::Matchers
-      
+
       handle_missingly [:find_by_name], class_method: true do |name|
         return {foo: 'bar'}
       end
-      
+
       handle_missingly /^find_all_by_(\w+)$/, class_method: true do |matches, *args, &block|
         return matches
       end
     end
   end
-  
+
   let(:delegation_test) do
     Class.new(search_class) do
       handle_missingly [:find_by_foo], to: :proxy, class_method: true
-      
+
       def self.proxy
         OpenStruct.new({find_by_foo: "foo"})
       end
     end
   end
-  
-  
+
+
   it "should not break normal method_missing" do
     search_class.new.respond_to?("foo_bar_widget").should be_false
   end
-  
+
   it "should allow you to define class methods" do
     search_class.respond_to?("find_by_name").should be_true
     search_class.respond_to?("find_all_by_name").should be_true
     search_class.find_all_by_name.should be_a MatchData
     search_class.find_by_name.should be_a Hash
   end
-  
+
   it "should support delegation matchers" do
     delegation_test.respond_to?("find_by_foo").should be_true
     delegation_test.find_by_foo.should be_true
   end
-  
+
   it "should not make class methods avliable to instances" do
     search_class.new.respond_to?("find_by_name").should be_false
     lambda { search_class.new.find_by_name("foo") }.should raise_exception
   end
-  
+
   it "should work through inheritence" do
     delegation_test.respond_to?("find_all_by_name").should be_true
     delegation_test.find_all_by_name.should be_a MatchData


### PR DESCRIPTION
This allows missingly to define class methods as well for example:

``` ruby
class Thing
    include Missingly::Matchers

    handle_missingly /^find_by_(\w+)$/, class_method: true do |matches, *args, &block|
        SomeApi.search(field: matches[1], value: args[0])
    end
end

Thing.find_by_name("foo")
```

To make a handle_missingly call define class methods just set the option `class_method` to true.

This means that we can use this to provide ActiveRecord like system around our classes.

I've tested all the matchers when used as class methods and it all works.
