### PR TITLE
Fix error with passing arguments to class methods

### DIFF
--- a/lib/missingly/matchers.rb
+++ b/lib/missingly/matchers.rb
@@ -108,7 +108,7 @@ module Missingly
           Missingly::Mutex.synchronize do
             missingly_methods_for_matcher(matcher.matchable) << method_name
 
-            returned_value = matcher.define(self, method_name, *args, &block)
+            returned_value = matcher.define(self, method_name)
 
             missingly_subclasses.each do |subclass|
               subclass.undef_parent_missingly_methods matcher.matchable

--- a/spec/class_methods_spec.rb
+++ b/spec/class_methods_spec.rb
@@ -5,8 +5,8 @@ describe Missingly::Matchers do
     Class.new do
       include Missingly::Matchers
 
-      handle_missingly [:find_by_name], class_method: true do |name|
-        return {foo: 'bar'}
+      handle_missingly [:find_by_name], class_method: true do |method_name, *args|
+        return {foo: args.first || 'bar'}
       end
 
       handle_missingly /^find_all_by_(\w+)$/, class_method: true do |matches, *args, &block|
@@ -42,7 +42,7 @@ describe Missingly::Matchers do
     delegation_test.find_by_foo.should be_true
   end
 
-  it "should not make class methods avliable to instances" do
+  it "should not make class methods available to instances" do
     search_class.new.respond_to?("find_by_name").should be_false
     lambda { search_class.new.find_by_name("foo") }.should raise_exception
   end
@@ -50,5 +50,9 @@ describe Missingly::Matchers do
   it "should work through inheritence" do
     delegation_test.respond_to?("find_all_by_name").should be_true
     delegation_test.find_all_by_name.should be_a MatchData
+  end
+
+  it "should accept method arguments" do
+    search_class.find_by_name("arg_test").should == {foo: "arg_test"}
   end
 end


### PR DESCRIPTION
Hi Thijs,

I saw your lightning talk at boston.rb and am starting to use your gem to build dynamic class methods. I found this bug however when creating class methods that expect arguments. I added a test and fixed the bug. Otherwise things seem to be working fine. Thanks!

Andy Hartford
